### PR TITLE
Use defcustom instead of defvar

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    paths-ignore:
+    - '**.md'
+    - 'tools/*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+          # - 26.1
+          # - 26.2
+          # - 26.3
+          - snapshot
+    steps:
+    - uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+
+    - uses: actions/checkout@v1
+    - name: Build configuration
+      run: './run-tests.sh'

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,20 +2,24 @@
 
 set -e
 
-if [[ $(uname -s) == "Darwin" ]]; then
-    EMACS_BIN=/Applications/Emacs.app/Contents/MacOS/Emacs
-else
-    EMACS_BIN=emacs
-fi
+EMACS="${EMACS:=emacs}"
 
-function elpa_dep_dir() {
-    echo $(find ~/.emacs.d/elpa -type d -depth 1 | grep -E "/$1-\d+\.\d+" | sort -r | head -n 1)
-}
+NEEDED_PACKAGES="dash s"
 
-$EMACS_BIN -batch \
+INIT_PACKAGE_EL="(progn \
+  (require 'package) \
+  (push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives) \
+  (package-initialize) \
+  (unless package-archive-contents \
+     (package-refresh-contents)) \
+  (dolist (pkg '(${NEEDED_PACKAGES})) \
+    (unless (package-installed-p pkg) \
+      (package-install pkg))))"
+
+
+${EMACS} -Q -batch \
+      --eval "$INIT_PACKAGE_EL" \
       -L . \
-      -L $(elpa_dep_dir "dash") \
-      -L $(elpa_dep_dir "s") \
       -l ert \
       -l ./sphinx-doc-tests.el \
       -f ert-run-tests-batch-and-exit

--- a/sphinx-doc-tests.el
+++ b/sphinx-doc-tests.el
@@ -97,7 +97,16 @@
                                       :after-fields ""
                                       :fields (list (make-sphinx-doc-field :key "param" :arg "name")
                                                     (make-sphinx-doc-field :key "returns" :desc "constant 42")
-                                                    (make-sphinx-doc-field :key "rtype" :desc "integer"))))))
+                                                    (make-sphinx-doc-field :key "rtype" :desc "integer")))))
+
+  (should (equal (sphinx-doc-parse "FIXME! briefly describe function\n\n    :param name: \n    :returns: constant 42\n    :rtype: integer\n\n    " 4)
+                 (make-sphinx-doc-doc :summary "FIXME! briefly describe function"
+                                      :before-fields ""
+                                      :after-fields ""
+                                      :fields (list (make-sphinx-doc-field :key "param" :arg "name")
+                                                    (make-sphinx-doc-field :key "returns" :desc "constant 42")
+                                                    (make-sphinx-doc-field :key "rtype" :desc "integer")))))
+  )
 
 
 (ert-deftest sphinx-doc-test-lines->paras ()
@@ -226,3 +235,33 @@
                          (make-sphinx-doc-field :key "returns" :type nil :arg nil :desc "constant 42")
                          (make-sphinx-doc-field :key "rtype" :type nil :arg nil :desc "integer")
                          (make-sphinx-doc-field :key "raises" :type nil :arg nil :desc "KeyError"))))))
+
+(ert-deftest sphinx-doc-test-str->fndef ()
+  (should (equal
+           (sphinx-doc-str->fndef "def fun(a, b):")
+           (make-sphinx-doc-fndef
+            :name "fun"
+            :args (list (make-sphinx-doc-arg :name "a")
+                        (make-sphinx-doc-arg :name "b")))))
+
+  (should (equal
+           (sphinx-doc-str->fndef "def fun(a: int, b):")
+           (make-sphinx-doc-fndef
+            :name "fun"
+            :args (list (make-sphinx-doc-arg :name "a" :type "int")
+                        (make-sphinx-doc-arg :name "b")))))
+
+  (should (equal
+           (sphinx-doc-str->fndef "def fun(a, b: Optional[str]):")
+           (make-sphinx-doc-fndef
+            :name "fun"
+            :args (list (make-sphinx-doc-arg :name "a")
+                        (make-sphinx-doc-arg :name "b" :type "Optional[str]")))))
+
+  (should (equal
+           (sphinx-doc-str->fndef "def fun(a, b: Union[str, list]):")
+           (make-sphinx-doc-fndef
+            :name "fun"
+            :args (list (make-sphinx-doc-arg :name "a")
+                        (make-sphinx-doc-arg :name "b" :type "Union[str, list]")))))
+  )

--- a/sphinx-doc-tests.el
+++ b/sphinx-doc-tests.el
@@ -2,6 +2,8 @@
 
 (require 'sphinx-doc)
 
+(customize-set-variable 'sphinx-doc-include-types nil)
+
 
 (ert-deftest sphinx-doc-test-str->arg ()
   (should (equal (sphinx-doc-str->arg "email")
@@ -22,7 +24,8 @@
                  (make-sphinx-doc-doc :fields (list (make-sphinx-doc-field :key "param" :arg "name")
                                                     (make-sphinx-doc-field :key "param" :arg "greeting")
                                                     (make-sphinx-doc-field :key "returns")
-                                                    (make-sphinx-doc-field :key "rtype"))))))
+                                                    ;; (make-sphinx-doc-field :key "rtype")
+                                                    )))))
 
 
 (ert-deftest sphinx-doc-test-fun-args ()
@@ -65,25 +68,29 @@
 
 
 (ert-deftest sphinx-doc-test-doc->str ()
-  (let ((d1 [cl-struct-sphinx-doc-doc "FIXME! briefly describe function" nil nil
-                                      ([cl-struct-sphinx-doc-field "param" nil "name" ""]
-                                       [cl-struct-sphinx-doc-field "returns" nil nil ""]
-                                       [cl-struct-sphinx-doc-field "rtype" nil nil ""])])
-        (d2 [cl-struct-sphinx-doc-doc "Just another function"
-                                      "This is some text before the fields section."
-                                      "This is some text after the fields section."
-                                      ([cl-struct-sphinx-doc-field "param" nil "name" ""]
-                                       [cl-struct-sphinx-doc-field "returns" nil nil "constant 42"]
-                                       [cl-struct-sphinx-doc-field "rtype" nil nil "integer"])]))
+  (let ((d1 (make-sphinx-doc-doc :summary "FIXME! briefly describe function"
+                                 :before-fields ""
+                                 :after-fields ""
+                                 :fields (list (make-sphinx-doc-field :key "param" :arg "name")
+                                               (make-sphinx-doc-field :key "returns")
+                                               (make-sphinx-doc-field :key "rtype")
+                                       )))
+        (d2 (make-sphinx-doc-doc :summary "Just another function"
+                                 :before-fields "This is some text before the fields section."
+                                 :after-fields "This is some text after the fields section."
+                                 :fields (list (make-sphinx-doc-field :key "param" :arg "name")
+                                               (make-sphinx-doc-field :key "returns" :desc "constant 42")
+                                               (make-sphinx-doc-field :key "rtype" :desc "integer")
+                                               ))))
     (should (string= (sphinx-doc-doc->str d1)
                      "\"\"\"FIXME! briefly describe function\n\n:param name: \n:returns: \n:rtype: \n\n\"\"\""))
     (should (string= (sphinx-doc-doc->str d2)
-                     "\"\"\"Just another function\n\nThis is some text before the fields section.\n\n:param name: \n:returns: constant 42\n:rtype: integer\n\nThis is some text after the fields section.\n\n\"\"\""))))
+                     "\"\"\"Just another function\n\nThis is some text before the fields section.\n\n:param name: \n:returns: constant 42\n:rtype: integer\n\nThis is some text after the fields section.\n\"\"\""))))
 
 
 (ert-deftest sphinx-doc-test-parse ()
   (should (equal (sphinx-doc-parse "This is a docstring without params." 0)
-                 [cl-struct-sphinx-doc-doc "This is a docstring without params." "" "" nil]))
+                 (make-sphinx-doc-doc :summary "This is a docstring without params." :before-fields "" :after-fields "" :fields nil)))
   (should (equal (sphinx-doc-parse "FIXME! briefly describe function\n\n    :param name: \n    :returns: constant 42\n    :rtype: integer\n\n    " 4)
                  (make-sphinx-doc-doc :summary "FIXME! briefly describe function"
                                       :before-fields ""
@@ -156,65 +163,66 @@
            '()))
   (should (equal
            (sphinx-doc-parse-fields
-            '(":param str sender: email address of the sender"
-              "                   this is the second line of sender param"
-              ":param str recipient: email address of the receiver"
-              ":param str message_body: message to send"
-              ":param priority: priority of message sending which is"
-              "                 is determined by joining date"
-              ":returns: this is a case where the return spans more"
-              "          than two lines. So I need to add a third line"
-              "          here and see if tests pass"
-              ":rtype: None"))
-           '([cl-struct-sphinx-doc-field "param" "str" "sender" "email address of the sender\n                   this is the second line of sender param"]
-             [cl-struct-sphinx-doc-field "param" "str" "recipient" "email address of the receiver"]
-             [cl-struct-sphinx-doc-field "param" "str" "message_body" "message to send"]
-             [cl-struct-sphinx-doc-field "param" nil "priority" "priority of message sending which is\n                 is determined by joining date"]
-             [cl-struct-sphinx-doc-field "returns" nil nil "this is a case where the return spans more\n          than two lines. So I need to add a third line\n          here and see if tests pass"]
-             [cl-struct-sphinx-doc-field "rtype" nil nil "None"])))
+            (list ":param str sender: email address of the sender"
+                  "                   this is the second line of sender param"
+                  ":param str recipient: email address of the receiver"
+                  ":param str message_body: message to send"
+                  ":param priority: priority of message sending which is"
+                  "                 is determined by joining date"
+                  ":returns: this is a case where the return spans more"
+                  "          than two lines. So I need to add a third line"
+                  "          here and see if tests pass"
+                  ":rtype: None"))
+           (list (make-sphinx-doc-field :key "param" :type "str" :arg "sender" :desc "email address of the sender\n                   this is the second line of sender param")
+                 (make-sphinx-doc-field :key "param" :type "str" :arg "recipient" :desc "email address of the receiver")
+                 (make-sphinx-doc-field :key "param" :type "str" :arg "message_body" :desc "message to send")
+                 (make-sphinx-doc-field :key "param" :type nil :arg "priority" :desc "priority of message sending which is\n                 is determined by joining date")
+                 (make-sphinx-doc-field :key "returns" :type nil :arg nil :desc "this is a case where the return spans more\n          than two lines. So I need to add a third line\n          here and see if tests pass")
+                 (make-sphinx-doc-field :key "rtype" :type nil :arg nil :desc "None"))))
   (should (equal
            (sphinx-doc-parse-fields
-            '(":param str sender: email address of the sender"
-              "                   this is the second line of sender param"
-              "                   this is the third line of sender param"
-              ":param int priority: priority"
-              ":returns:"
-              ":rtype: None"))
-           '([cl-struct-sphinx-doc-field "param" "str" "sender" "email address of the sender\n                   this is the second line of sender param\n                   this is the third line of sender param"]
-             [cl-struct-sphinx-doc-field "param" "int" "priority" "priority"]
-             [cl-struct-sphinx-doc-field "returns" nil nil ""]
-             [cl-struct-sphinx-doc-field "rtype" nil nil "None"]))))
+            (list ":param str sender: email address of the sender"
+                  "                   this is the second line of sender param"
+                  "                   this is the third line of sender param"
+                  ":param int priority: priority"
+                  ":returns:"
+                  ":rtype: None"))
+           (list (make-sphinx-doc-field :key "param" :type "str" :arg "sender" :desc "email address of the sender\n                   this is the second line of sender param\n                   this is the third line of sender param")
+                 (make-sphinx-doc-field :key "param" :type "int" :arg "priority" :desc "priority")
+                 (make-sphinx-doc-field :key "returns" :type nil :arg nil :desc "")
+                 (make-sphinx-doc-field :key "rtype" :type nil :arg nil :desc "None")))))
 
 
 (ert-deftest sphinx-doc-test-merge-fields ()
-  (let ((t1-old '([cl-struct-sphinx-doc-field "param" "str" "name" "This is name"]
-                  [cl-struct-sphinx-doc-field "returns" nil nil "constant 42"]
-                  [cl-struct-sphinx-doc-field "rtype" nil nil "integer"]))
+  (let ((t1-old (list (make-sphinx-doc-field :key "param" :type "str" :arg "name" :desc "This is name")
+                      (make-sphinx-doc-field :key "returns" :type nil :arg nil :desc "constant 42")
+                      (make-sphinx-doc-field :key "rtype" :type nil :arg nil :desc "integer")))
 
-        (t1-new '([cl-struct-sphinx-doc-field "param" nil "name" ""]
-                  [cl-struct-sphinx-doc-field "param" nil "age" ""]
-                  [cl-struct-sphinx-doc-field "returns" nil nil ""]
-                  [cl-struct-sphinx-doc-field "rtype" nil nil ""]))
+        (t1-new (list (make-sphinx-doc-field :key "param" :type nil :arg "name" :desc "")
+                      (make-sphinx-doc-field :key "param" :type nil :arg "age" :desc "")
+                      (make-sphinx-doc-field :key "returns" :type nil :arg nil :desc "")
+                      (make-sphinx-doc-field :key "rtype" :type nil :arg nil :desc "")))
 
-        (t2-old '([cl-struct-sphinx-doc-field "param" nil "name" "name of the person"]
-                  [cl-struct-sphinx-doc-field "type" nil "name" "str"]
-                  [cl-struct-sphinx-doc-field "returns" nil nil "constant 42"]
-                  [cl-struct-sphinx-doc-field "rtype" nil nil "integer"]
-                  [cl-struct-sphinx-doc-field "raises" nil nil "KeyError"]))
+        (t2-old (list (make-sphinx-doc-field :key "param" :type nil :arg "name" :desc "name of the person")
+                      (make-sphinx-doc-field :key "type" :type nil :arg "name" :desc "str")
+                      (make-sphinx-doc-field :key "returns" :type nil :arg nil :desc "constant 42")
+                      (make-sphinx-doc-field :key "rtype" :type nil :arg nil :desc "integer")
+                      (make-sphinx-doc-field :key "raises" :type nil :arg nil :desc "KeyError")))
 
-        (t2-new '([cl-struct-sphinx-doc-field "param" nil "name" ""]
-                  [cl-struct-sphinx-doc-field "param" nil "age" ""]
-                  [cl-struct-sphinx-doc-field "returns" nil nil ""]
-                  [cl-struct-sphinx-doc-field "rtype" nil nil ""])))
+        (t2-new (list (make-sphinx-doc-field :key "param" :type nil :arg "name" :desc "")
+                      (make-sphinx-doc-field :key "param" :type nil :arg "age" :desc "")
+                      (make-sphinx-doc-field :key "returns" :type nil :arg nil :desc "")
+                      (make-sphinx-doc-field :key "rtype" :type nil :arg nil :desc ""))))
     (should (equal (sphinx-doc-merge-fields t1-old t1-new)
                    (list (make-sphinx-doc-field :key "param" :arg "name" :type "str" :desc "This is name")
-                         (make-sphinx-doc-field :key "param" :arg "age" :desc "")
-                         (make-sphinx-doc-field :key "returns" :desc "constant 42")
-                         (make-sphinx-doc-field :key "rtype" :desc "integer"))))
+                         (make-sphinx-doc-field :key "param" :arg "age" :type nil :desc "")
+                         (make-sphinx-doc-field :key "returns" :type nil :desc "constant 42")
+                         (make-sphinx-doc-field :key "rtype" :type nil :desc "integer"))))
+
     (should (equal (sphinx-doc-merge-fields t2-old t2-new)
-                   '([cl-struct-sphinx-doc-field "param" nil "name" "name of the person"]
-                     [cl-struct-sphinx-doc-field "type" nil "name" "str"]
-                     [cl-struct-sphinx-doc-field "param" nil "age" ""]
-                     [cl-struct-sphinx-doc-field "returns" nil nil "constant 42"]
-                     [cl-struct-sphinx-doc-field "rtype" nil nil "integer"]
-                     [cl-struct-sphinx-doc-field "raises" nil nil "KeyError"])))))
+                   (list (make-sphinx-doc-field :key "param" :type nil :arg "name" :desc "name of the person")
+                         (make-sphinx-doc-field :key "type" :type nil :arg "name" :desc "str")
+                         (make-sphinx-doc-field :key "param" :type nil :arg "age" :desc "")
+                         (make-sphinx-doc-field :key "returns" :type nil :arg nil :desc "constant 42")
+                         (make-sphinx-doc-field :key "rtype" :type nil :arg nil :desc "integer")
+                         (make-sphinx-doc-field :key "raises" :type nil :arg nil :desc "KeyError"))))))

--- a/sphinx-doc.el
+++ b/sphinx-doc.el
@@ -73,8 +73,10 @@
 (defconst sphinx-doc-raises-variants '("raises" "raise" "except" "exception"))
 (defconst sphinx-doc-returns-variants '("returns" "return"))
 
-(defvar sphinx-doc-python-indent)
-(defvar sphinx-doc-include-types)
+(defcustom sphinx-doc-python-indent t
+  "If non-nil, the docstring will be indented.")
+(defcustom sphinx-doc-include-types t
+  "If non-nil, the docstring will also include the type.")
 
 ;; struct definitions
 


### PR DESCRIPTION
So that users can override the value for

- sphinx-doc-python-indent
- sphinx-doc-include-types

And set a default value to fix the error message:

```
let*: Symbol’s value as variable is void: sphinx-doc-include-types
```

## Unit tests CI

* unit tests fixed
* added github CI workflow